### PR TITLE
[FEAT] Aura conditional visibility system

### DIFF
--- a/src/features/portal/minigame/Constants.ts
+++ b/src/features/portal/minigame/Constants.ts
@@ -3,6 +3,7 @@ import { translate as t } from "lib/i18n/translate";
 import { NPC_WEARABLES } from "lib/npcs";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { Position, Side } from "./Types";
+import { BumpkinAura } from "features/game/types/bumpkin";
 
 export const PORTAL_NAME = "april-fools";
 export const PORTAL_TOKEN = "April Fools Token 2025";
@@ -94,7 +95,19 @@ export const ENEMIES_TABLE: {
       image: ITEM_DETAILS["Abandoned Bear"].image,
       description: t(`${PORTAL_NAME}.enemy2`),
     },
-  ];
+];
+
+export const VISIBLE_AURA: BumpkinAura[] = [
+    "Slime Aura",
+    "Wisp Aura",
+    "Diamond Snow Aura",
+];
+
+export const NOT_VISIBLE_AURA: BumpkinAura[] = [
+    "Coin Aura",
+    "Love Puff Aura",
+    "Paw Aura",
+];
 
 // Panel
 export const PANEL_NPC_WEARABLES: Equipped = NPC_WEARABLES["elf"];

--- a/src/features/portal/minigame/containers/Menace_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Menace_Skeleton.ts
@@ -2,6 +2,7 @@ import { BumpkinContainer } from "../Core/BumpkinContainer";
 import { Scene } from "../Scene";
 import { createAnimation } from "../lib/Utils";
 import { MachineInterpreter } from "../lib/Machine";
+import { VISIBLE_AURA, NOT_VISIBLE_AURA } from "../Constants";
 
 interface Props {
     x: number;
@@ -22,7 +23,6 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     private vegeList: string[];
     private flipX: boolean = false;
     private randomThrow: number;
-
     constructor({ x, y, scene, player }: Props) {
         super(scene, x, y);
         this.scene = scene
@@ -185,12 +185,16 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     }
 
     private createReset() {
-        this.scene.time.delayedCall(3000, () => {
+        this.scene.time.delayedCall(4000, () => {
             if (!this.player) return;
             this.vegeSplat.setVisible(false);
             (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = false;
             (this.sprite.body as Phaser.Physics.Arcade.Body).enable = false;
             this.vege.setTexture(`${this.spriteName}_${this.randomVege}`);
+
+            this.player?.sprite?.setVisible(true);
+            this.player?.shadow?.setVisible(true);
+            this.player.setVisible(true);
         });
     }
 
@@ -198,8 +202,22 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
         if (!this.player) return;
         this.scene.physics.add.overlap(this.vegeSplat, this.player, () => {
             this.vegeSplat.setVisible(false);
-            this.player?.setVisible(false);
             (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = false;
+
+            if (this.player) {
+                if (this.player.clothing.aura && VISIBLE_AURA.includes(this.player.clothing.aura)) {
+                    // Aura is visible
+                    this.player?.sprite?.setVisible(false);
+                    this.player?.shadow?.setVisible(false);
+                    this.player.showAura();
+                } else if (this.player.clothing.aura && NOT_VISIBLE_AURA.includes(this.player.clothing.aura)) {
+                    // Aura is not visible
+                    this.player.setVisible(false);
+                } else {
+                    // Default case
+                    this.player.showAura();
+                }
+            }
         }
         )
     }


### PR DESCRIPTION
# Description

Aura Conditional Visibility System – This feature controls which parts of the player are visible when hit by a projectile, depending on the equipped aura. If the player has a “visible” aura, the aura remains visible while the body and shadow are hidden. If the player has a “non-visible” aura, both the aura and the player are hidden. This ensures dynamic visual feedback based on aura type.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
