### PR TITLE
[FEAT] Implement Menace Skeleton Defeat and Respawn Mechanic

### DIFF
--- a/src/features/portal/minigame/containers/Menace_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Menace_Skeleton.ts
@@ -11,6 +11,12 @@ interface Props {
     player?: BumpkinContainer,
 }
 
+const SPLAT_SIZE = 15;
+const MENACE_MIN_DELAY = 6000;
+const MENACE_MAX_DELAY = 8000;
+const RESPAWN_DELAY = 15000;
+const HIT_DURATION = 4000;
+
 export class Menace_Skeleton extends Phaser.GameObjects.Container {
     scene: Scene;
     private player?: BumpkinContainer;
@@ -23,9 +29,14 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     private vegeList: string[];
     private flipX: boolean = false;
     private randomThrow: number;
+    private isDefeated: boolean = false;
+    private skeletonTimer?: Phaser.Time.TimerEvent;
+    private isHit: boolean = false;
+
     constructor({ x, y, scene, player }: Props) {
         super(scene, x, y);
-        this.scene = scene
+
+        this.scene = scene;
         this.player = player;
         this.spriteName = "sniper_skeleton";
 
@@ -35,71 +46,62 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
         this.randomThrow = Phaser.Math.Between(-50, 50);
         this.flipX = this.randomThrow <= 0;
 
+        // Sprites
         this.sprite = this.scene.add.sprite(0, 0, `${this.spriteName}_move`).setVisible(false);
         this.vege = this.scene.add.sprite(0, 0, `${this.spriteName}_${this.randomVege}`).setVisible(false);
         this.vegeSplat = this.scene.add.sprite(0, 0, `${this.spriteName}_${this.randomVege}_splat`).setVisible(false);
+
         this.add([this.sprite, this.vege]);
-        this.player?.setVisible(true)
+        this.player?.setVisible(true);
+
+        // Physics
         this.scene.physics.add.existing(this);
-        (this.body as Phaser.Physics.Arcade.Body)
-            .setSize(this.sprite.width, this.sprite.height);
+        (this.body as Phaser.Physics.Arcade.Body).setSize(this.sprite.width, this.sprite.height);
 
-        // Enemy
+        // Setup
         this.scheduleMenace();
-
-        // Overlaps
         this.createOverlaps();
-
-        // Events
-        this.createEvents();
-
-        // Damage
-        this.createDamage();
-
-        // Hit
-        this.createHit();
-
-        // Defeat
-        this.createDefeat
 
         scene.add.existing(this);
     }
 
-    public get portalService() {
-        return this.scene.registry.get("portalService") as
-            | MachineInterpreter
-            | undefined;
+    public get portalService(): MachineInterpreter | undefined {
+        return this.scene.registry.get("portalService") as MachineInterpreter | undefined;
     }
 
     private scheduleMenace() {
-        const delay = Phaser.Math.Between(6000, 8000);
-        this.scene.time.delayedCall(delay, () => {
-
-            this.createMenace();
-            this.scheduleMenace();
+        if (this.isDefeated) return;
+        const delay = Phaser.Math.Between(MENACE_MIN_DELAY, MENACE_MAX_DELAY);
+        this.skeletonTimer = this.scene.time.delayedCall(delay, () => {
+            if (!this.isDefeated) {
+                this.createMenace();
+                this.scheduleMenace();
+            }
         });
     }
 
     private createMenace() {
         if (!this.player) return;
 
-        this.player.setVisible(true);
         this.sprite.setVisible(true);
+
         this.playerWorldX_Sprite = this.player.getWorldTransformMatrix().tx;
         this.randomVege = Phaser.Math.RND.pick(this.vegeList);
+
         this.vege.setTexture(`${this.spriteName}_${this.randomVege}`);
         this.vege.setVisible(true);
 
         this.randomThrow = Phaser.Math.Between(-50, 50);
         this.flipX = this.randomThrow <= 0;
 
-        const switchSide = this.flipX === true ? this.sprite.x + 10 : this.sprite.x - 10;
-        this.flipX === true ? this.vege.setFlipX(true) : this.vege.setFlipX(false);
+        const switchSide = this.flipX ? this.sprite.x + 10 : this.sprite.x - 10;
+        this.vege.setFlipX(this.flipX);
         this.sprite.setFlipX(this.flipX);
         this.vege.setPosition(switchSide, 0);
 
+        // Physics for sprite
         this.scene.physics.add.existing(this.sprite);
-        const body = this.sprite.body as Phaser.Physics.Arcade.Body
+        const body = this.sprite.body as Phaser.Physics.Arcade.Body;
         body.setSize(this.sprite.width, this.sprite.height)
             .setCollideWorldBounds(true)
             .setImmovable(true);
@@ -107,34 +109,24 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
         this.setSize(this.sprite.width, this.sprite.height);
         this.setDepth(10);
 
-        createAnimation(
-            this.scene,
-            this.sprite,
-            `${this.spriteName}_idle`,
-            "idle",
-            0,
-            3,
-            4,
-            0
-        );
+        createAnimation(this.scene, this.sprite, `${this.spriteName}_idle`, "idle", 0, 3, 4, 0);
 
-        this.scene.time.delayedCall(650, () => {
-
-            this.foodMovement();
-        });
+        this.scene.time.delayedCall(650, () => this.foodMovement());
     }
 
     private foodMovement() {
         if (!this.player) return;
+
+        this.vegeSplat.setVisible(false);
         this.sprite.anims.remove("idle");
-        this.add(this.vegeSplat)
+        this.add(this.vegeSplat);
         this.scene.physics.add.existing(this.vegeSplat);
 
         const splatBody = this.vegeSplat.body as Phaser.Physics.Arcade.Body;
         splatBody.enable = false;
         splatBody.setAllowGravity(false);
         splatBody.setImmovable(true);
-        splatBody.setSize(15, 15, true);
+        splatBody.setSize(SPLAT_SIZE, SPLAT_SIZE, true);
 
         const playerWorldY = this.player.getWorldTransformMatrix().ty;
         const throwSpeed = playerWorldY < 297 ? 250 : 300;
@@ -142,7 +134,6 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
         this.vege.setFlipX(this.flipX);
         this.vegeSplat.setFlipX(this.flipX);
         this.vegeSplat.setPosition(this.randomThrow, playerWorldY - this.y);
-        console.log(playerWorldY, throwSpeed);
 
         this.scene.add.tween({
             targets: this.vege,
@@ -151,16 +142,7 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
             duration: throwSpeed,
             ease: 'Quad.Out',
             onComplete: () => {
-                createAnimation(
-                    this.scene,
-                    this.sprite,
-                    `${this.spriteName}_move`,
-                    "move",
-                    0,
-                    3,
-                    4,
-                    -1
-                );
+                createAnimation(this.scene, this.sprite, `${this.spriteName}_move`, "move", 0, 3, 4, -1);
             }
         });
 
@@ -168,78 +150,95 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
             this.vege.setVisible(false);
             this.vegeSplat.setVisible(true);
             splatBody.enable = true;
-            createAnimation(
-                this.scene,
-                this.vegeSplat,
-                `${this.spriteName}_${this.randomVege}_splat`,
-                "splat",
-                0,
-                4,
-                30,
-                0
-            );
-        }
-        );
-
-        this.createReset();
-    }
-
-    private createReset() {
-        this.scene.time.delayedCall(4000, () => {
-            if (!this.player) return;
-            this.vegeSplat.setVisible(false);
-            (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = false;
-            (this.sprite.body as Phaser.Physics.Arcade.Body).enable = false;
-            this.vege.setTexture(`${this.spriteName}_${this.randomVege}`);
-
-            this.player?.sprite?.setVisible(true);
-            this.player?.shadow?.setVisible(true);
-            this.player.setVisible(true);
+            createAnimation(this.scene, this.vegeSplat, `${this.spriteName}_${this.randomVege}_splat`, "splat", 0, 4, 30, 0);
         });
     }
 
     private createOverlaps() {
         if (!this.player) return;
-        this.scene.physics.add.overlap(this.vegeSplat, this.player, () => {
+
+        this.scene.physics.add.overlap(this.vegeSplat, this.player,  () => {
             this.vegeSplat.setVisible(false);
-            
-            if (this.player) {
-                const aura = this.player.clothing.aura;
-                
-                if (!aura) {
-                    // No aura in inventory
-                    this.player.setVisible(false);
-                } else if (VISIBLE_AURA.includes(aura)) {
-                    // Aura is visible
-                    this.player?.sprite?.setVisible(false);
-                    this.player?.shadow?.setVisible(false);
-                    this.player.showAura();
-                } else if (NOT_VISIBLE_AURA.includes(aura)) {
-                    // Aura is not visible
-                    this.player.setVisible(false);
-                } else {
-                    // Default case
-                    this.player.showAura();
-                }
-            }
+            this.createHit();
             (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = false;
+        });
+    }
+
+    private createHit() {
+        if (!this.player || this.isHit) return;
+
+        this.isHit = true;
+
+        const aura = this.player.clothing.aura;
+
+        if (!aura) {
+            this.player.setVisible(false);
+        } else if (VISIBLE_AURA.includes(aura)) {
+            this.player?.sprite?.setVisible(false);
+            this.player?.shadow?.setVisible(false);
+            this.player.showAura();
+        } else if (NOT_VISIBLE_AURA.includes(aura)) {
+            this.player.setVisible(false);
+        } else {
+            this.player.showAura();
         }
-    )
+
+        this.scene.time.delayedCall(HIT_DURATION, () => {
+            this.restorePlayer();
+        });
     }
 
-    private createDamage() {
+    private restorePlayer() {
         if (!this.player) return;
+
+        this.isHit = true;
+
+        this.player.setVisible(true);
+        this.player?.sprite?.setVisible(true);
+        this.player?.shadow?.setVisible(true);
+
+        this.isHit = false;
     }
 
-    private createHit() { }
-
+    private createDamage() { }
     private createEvents() { }
 
-    private createDefeat() { }
-
     public defeat() {
+        if (this.isDefeated || !this.vegeSplat.visible) return;
+        this.isDefeated = true;
+
         this.sprite.setVisible(false);
         this.vege.setVisible(false);
         this.vegeSplat.setVisible(false);
+
+        this.skeletonTimer?.remove(false);
+
+        this.scene.tweens.killTweensOf(this.sprite);
+        this.scene.tweens.killTweensOf(this.vege);
+        this.scene.tweens.killTweensOf(this.vegeSplat);
+
+        (this.body as Phaser.Physics.Arcade.Body).enable = false;
+        (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = false;
+
+        this.respawn();
+    }
+
+    private respawn(delay: number = RESPAWN_DELAY) {
+        this.scene.time.delayedCall(delay, () => {
+            this.isDefeated = false;
+
+            this.sprite.setVisible(true);
+            this.vege.setVisible(false);
+            this.vegeSplat.setVisible(false);
+
+            this.sprite.setFlipX(false);
+            this.vege.setFlipX(false);
+            this.vegeSplat.setFlipX(false);
+
+            (this.body as Phaser.Physics.Arcade.Body).enable = true;
+            (this.vegeSplat.body as Phaser.Physics.Arcade.Body).enable = true;
+
+            this.scheduleMenace();
+        });
     }
 }


### PR DESCRIPTION
# Description
Adds defeat logic for Menace Skeleton, disabling its sprites, physics, and tweens when defeated, and automatically respawning it after a delay.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
