### PR TITLE
[FEAT] Implement Giant Skeleton Defeat and Respawn Mechanic

### DIFF
--- a/src/features/portal/minigame/containers/Giant_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Giant_Skeleton.ts
@@ -2,159 +2,243 @@ import { BumpkinContainer } from "../Core/BumpkinContainer";
 import { Scene } from "../Scene";
 import { createAnimation } from "../lib/Utils";
 import { MachineInterpreter } from "../lib/Machine";
+import { WING_BUFF } from "../Constants";
 
 interface Props {
-    x: number;
-    y: number;
-    scene: Scene,
-    player?: BumpkinContainer,
+  x: number;
+  y: number;
+  scene: Scene;
+  player?: BumpkinContainer;
 }
 
+const MOVE_DISTANCE = 90;
+const MIN_BARREL_THROW_DELAY = 2000;
+const MAX_BARREL_THROW_DELAY = 6000;
+const BARREL_RESET_DELAY = 3000;
+const RESPAWN_DELAY = 10000;
+
 export class Giant_Skeleton extends Phaser.GameObjects.Container {
-    scene: Scene;
-    private player?: BumpkinContainer;
-    private sprite: Phaser.GameObjects.Sprite;
-    private barrel: Phaser.GameObjects.Sprite;
-    private spriteName: string;
-    private direction: number = 1;
-    private followGiant: boolean = true;
+  scene: Scene;
+  private player?: BumpkinContainer;
+  private sprite: Phaser.GameObjects.Sprite;
+  private barrel: Phaser.GameObjects.Sprite;
+  private spriteName: string;
+  private direction: number = 1;
+  private followGiant: boolean = true;
+  private isDefeated: boolean = false;
+  private barrelTimer?: Phaser.Time.TimerEvent;
 
-    constructor({ x, y, scene, player }: Props) {
-        super(scene, x, y);
-        this.scene = scene
-        this.player = player;
-        this.spriteName = "giant_skeleton";
+  constructor({ x, y, scene, player }: Props) {
+    super(scene, x, y);
 
-        this.sprite = this.scene.add.sprite(0, 0, `${this.spriteName}_idle`);
-        this.barrel = this.scene.add.sprite(0, -20, `${this.spriteName}_barrel`)
-        this.add([this.sprite, this.barrel])
-        this.scene.physics.add.existing(this.barrel);
-        this.scene.physics.add.existing(this);
-        (this.body as Phaser.Physics.Arcade.Body)
-            .setSize(this.sprite.width, this.sprite.height);
+    this.scene = scene;
+    this.player = player;
+    this.spriteName = "giant_skeleton";
 
-        // // Giant skeleton
-        this.createGiant();
+    // Sprites
+    this.sprite = this.scene.add.sprite(0, 0, `${this.spriteName}_idle`);
+    this.barrel = this.scene.add.sprite(0, -20, `${this.spriteName}_barrel`);
+    this.add([this.sprite, this.barrel]);
 
-        // // Barrel
-        this.throwBarrelLoop();
+    // Physics
+    this.scene.physics.add.existing(this.barrel);
+    this.scene.physics.add.existing(this);
+    (this.body as Phaser.Physics.Arcade.Body).setSize(
+      this.sprite.width,
+      this.sprite.height,
+    );
 
-        // // Overlap
-        this.createOverlaps();
+    // Setup
+    this.createGiant();
+    this.createOverlaps();
 
-        scene.add.existing(this);
+    scene.add.existing(this);
+  }
+
+  public get portalService(): MachineInterpreter | undefined {
+    return this.scene.registry.get("portalService") as
+      | MachineInterpreter
+      | undefined;
+  }
+
+  private createGiant() {
+    this.setSize(this.sprite.width, this.sprite.height);
+    this.setDepth(0);
+
+    createAnimation(
+      this.scene,
+      this.sprite,
+      `${this.spriteName}_idle`,
+      "idle",
+      0,
+      3,
+      4,
+      -1,
+    );
+
+    const moveLeft = this.x - MOVE_DISTANCE;
+    const moveRight = 450;
+    this.x = moveLeft;
+
+    let prevX = this.x;
+
+    this.scene.tweens.add({
+      targets: this,
+      x: moveRight,
+      duration: 15000,
+      ease: "Linear",
+      yoyo: true,
+      repeat: -1,
+      onUpdate: (tween, target: any) => {
+        if (this.followGiant) {
+          this.barrel.x = this.sprite.x;
+          this.barrel.y = this.sprite.y - 20;
+        }
+
+        const dx = target.x - prevX;
+        if (dx < 0) {
+          this.sprite.setFlipX(true);
+          this.barrel.setFlipX(true);
+          this.direction = -1;
+        } else if (dx > 0) {
+          this.sprite.setFlipX(false);
+          this.barrel.setFlipX(false);
+          this.direction = 1;
+        }
+        prevX = target.x;
+      },
+    });
+
+    this.scheduleNextBarrelThrow();
+  }
+
+  private scheduleNextBarrelThrow() {
+    if (this.isDefeated) return;
+    const delay = Phaser.Math.RND.between(
+      MIN_BARREL_THROW_DELAY,
+      MAX_BARREL_THROW_DELAY,
+    );
+    this.barrelTimer?.remove(false);
+    this.barrelTimer = this.scene.time.delayedCall(delay, () => {
+      if (!this.isDefeated) this.throwBarrel();
+    });
+  }
+
+  private throwBarrel() {
+    if (!this.player) return;
+
+    this.followGiant = false;
+
+    const body = this.barrel.body as Phaser.Physics.Arcade.Body;
+    body.enable = true;
+    body.setCollideWorldBounds(false);
+    body.setImmovable(true);
+
+    this.setDepth(200);
+
+    const distance = this.direction === 1 ? "+=150" : "-=150";
+    const valueY = this.player.getWorldTransformMatrix().ty - this.y;
+
+    this.scene.tweens.add({
+      targets: this.barrel,
+      props: {
+        x: { value: distance, duration: 2500, ease: "Power2" },
+        y: { value: `${valueY}`, duration: 2000, ease: "Bounce" },
+      },
+      onComplete: () => this.resetBarrel(),
+    });
+  }
+
+  private resetBarrel() {
+    this.barrel.setVisible(false);
+    this.barrel.setPosition(this.sprite.x, this.sprite.y - 20);
+    (this.barrel.body as Phaser.Physics.Arcade.Body).enable = false;
+    this.scene.tweens.killTweensOf(this.barrel);
+
+    if (this.isDefeated) return;
+
+    this.scene.time.delayedCall(BARREL_RESET_DELAY, () => {
+      if (this.isDefeated) return;
+
+      this.barrel.setVisible(true);
+      (this.barrel.body as Phaser.Physics.Arcade.Body).enable = true;
+      this.followGiant = true;
+
+      this.scheduleNextBarrelThrow();
+    });
+  }
+
+  private createOverlaps() {
+    if (!this.player) return;
+
+    const defaultScale = 1;
+
+    this.scene.physics.add.collider(this, this.player);
+    this.scene.physics.add.overlap(this.barrel, this.player, () => {
+      this.barrel.setVisible(false);
+      this.createHit();
+      this.barrel.setPosition(this.sprite.x, this.sprite.y - 20);
+      (this.barrel.body as Phaser.Physics.Arcade.Body).enable = false;
+
+      this.scene.time.delayedCall(3000, () =>
+        this.player?.setScale(defaultScale),
+      );
+    });
+  }
+
+  private createHit() {
+    if (!this.player) return;
+
+    const wing = this.player.clothing.wings;
+    const enlargePlayer = 1.5;
+    const defaultScale = 1;
+
+    if (!wing) {
+      this.player.setScale(enlargePlayer);
+    } else if (WING_BUFF.includes(wing)) {
+      this.player.setScale(defaultScale);
+    } else {
+      this.player.setScale(enlargePlayer);
     }
+  }
 
-    public get portalService() {
-        return this.scene.registry.get("portalService") as
-            | MachineInterpreter
-            | undefined;
-    }
+  private createDamage() {}
+  private createEvents() {}
 
-    private createGiant() {
-        this.setSize(this.sprite.width, this.sprite.height);
-        this.add(this.sprite);
-        this.setDepth(0);
+  public defeat() {
+    this.isDefeated = true;
 
-        createAnimation(this.scene, this.sprite, `${this.spriteName}_idle`, "idle", 0, 3, 4, -1)
+    this.barrel.setVisible(false);
+    this.sprite.setVisible(false);
 
-        const moveLeft = this.x - 90;
-        const moveRight = 335;
-        this.x = moveLeft;
+    this.barrelTimer?.remove(false);
 
-        let prevX = this.x
+    this.scene.tweens.killTweensOf(this.sprite);
+    this.scene.tweens.killTweensOf(this.barrel);
 
-        this.scene.tweens.add({
-            targets: this,
-            x: moveRight,
-            duration: 15000,
-            ease: "Linear",
-            yoyo: true,
-            repeat: -1,
-            onUpdate: (tween, target: any) => {
-                if (this.followGiant) {
-                    this.barrel.x = this.sprite.x;
-                    this.barrel.y = this.sprite.y - 20;
-                }
+    (this.body as Phaser.Physics.Arcade.Body).enable = false;
+    (this.barrel.body as Phaser.Physics.Arcade.Body).enable = false;
 
-                const dx = target.x - prevX;
-                if (dx < 0) {
-                    this.sprite.flipX = true;  // moving left
-                    this.direction = -1;
-                    this.barrel.flipX = true;
-                } else if (dx > 0) {
-                    this.sprite.flipX = false; // moving right
-                    this.direction = 1;
-                    this.barrel.flipX = false;
-                }
-                prevX = target.x;
-            }
-        })
-    }
+    this.respawn();
+  }
 
-    private throwBarrelLoop() {
-        const delay = Phaser.Math.Between(1000, 8000);
-        this.scene.time.delayedCall(delay, () => {
-            this.followGiant = false;
-            (this.barrel.body as Phaser.Physics.Arcade.Body).enable = false;
-            console.log("Barrel physics enabled?", (this.barrel.body as Phaser.Physics.Arcade.Body).enable);
-            this.barrelMovement(() => {
-                // After barrel resets, start next throw
-                this.throwBarrelLoop();
-            });
-        });
-    }
+  private respawn(delay: number = RESPAWN_DELAY) {
+    this.scene.time.delayedCall(delay, () => {
+      this.isDefeated = false;
 
-    private barrelMovement(onComplete?: () => void) {
-        if (!this.player) return;
-        const body = this.barrel.body as Phaser.Physics.Arcade.Body;
-        body.enable = true;
-        body.setCollideWorldBounds(false);
-        this.setDepth(200);
+      const moveLeft = this.x - MOVE_DISTANCE;
+      this.x = moveLeft;
 
-        const distance = this.direction === 1 ? "+=150" : "-=150"
-        const valueY = this.player.getWorldTransformMatrix().ty - this.y;
-        this.scene.tweens.add({
-            targets: this.barrel,
-            props: {
-                x: { value: distance, duration: 3000, ease: 'Power2' },
-                y: { value: `${valueY}`, duration: 2000, ease: 'Bounce' }
-            },
-        })
+      this.sprite.setVisible(true);
+      this.barrel.setVisible(true);
+      this.barrel.setPosition(this.sprite.x, this.sprite.y - 20);
 
-        this.scene.time.delayedCall(5000, () => {
-            this.barrel.setPosition(this.sprite.x, this.sprite.y - 20);
-            this.followGiant = true;
-            this.barrel.setVisible(true)
-            if (onComplete) onComplete();
-        })
+      (this.body as Phaser.Physics.Arcade.Body).enable = true;
+      (this.barrel.body as Phaser.Physics.Arcade.Body).enable = true;
 
-    }
+      this.followGiant = true;
 
-    private createOverlaps() {
-        if (!this.player) return;
-        const enlargePlayer = 1.5;
-        const deafaultScale = 1;
-
-        this.scene.physics.add.collider(this, this.player);
-        this.scene.physics.add.overlap(this.barrel, this.player, () => {
-            this.barrel.setVisible(false);
-            this.player?.setScale(enlargePlayer);
-            (this.barrel.body as Phaser.Physics.Arcade.Body).enable = false;
-            this.scene.time.delayedCall(3000, () => this.player?.setScale(deafaultScale))
-        });
-    }
-
-    private createDamage() { }
-
-    private createHit() { }
-
-    private createEvents() { }
-
-    private createDefeat() { }
-
-    public defeat() {
-        this.sprite.setVisible(false);
-        this.barrel.setVisible(false);
-    }
+      this.scheduleNextBarrelThrow();
+    });
+  }
 }


### PR DESCRIPTION
# Description
This code creates a Giant Skeleton enemy that moves back and forth and periodically throws a barrel at the player. When the barrel hits the player, the player becomes larger (debuff) unless they have a wing buff that grants immunity. The Giant Skeleton can also be defeated, temporarily disappear, and respawn after a delay, resetting its movement and attack behavior.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
