### PR TITLE
[FEAT] Add Equipment Immunity HUD indicator

### DIFF
--- a/src/features/portal/minigame/components/hud/EquipmentImmunity.tsx
+++ b/src/features/portal/minigame/components/hud/EquipmentImmunity.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { getWearableImage } from "features/game/lib/getWearableImage";
+import { Box } from "components/ui/Box";
+import { STATIC_OFFLINE_FARM } from "features/game/lib/landDataStatic";
+import { VISIBLE_AURA, WING_BUFF } from "../../Constants";
+
+export const Equipment_Immunity: React.FC = () => {
+  const { aura: equippedAura, wings: equippedWing } =
+    STATIC_OFFLINE_FARM.bumpkin.equipped;
+
+  const aura =
+    equippedAura && VISIBLE_AURA.includes(equippedAura)
+      ? equippedAura
+      : undefined;
+  const wings =
+    equippedWing && WING_BUFF.includes(equippedWing) ? equippedWing : undefined;
+
+  if (!aura && !wings) return null;
+
+  return (
+    <div className="relative flex flex-col items-end gap-3">
+      {aura && <Box image={getWearableImage(aura)} className="h-10" />}
+      {wings && <Box image={getWearableImage(wings)} className="h-10" />}
+    </div>
+  );
+};

--- a/src/features/portal/minigame/components/hud/Hud.tsx
+++ b/src/features/portal/minigame/components/hud/Hud.tsx
@@ -10,6 +10,7 @@ import { Travel } from "./Travel";
 import { Timer } from "./Timer";
 // import { Target } from "./Target";
 import { Lives } from "./Lives";
+import { Equipment_Immunity } from "./EquipmentImmunity";
 
 const _isJoystickActive = (state: PortalMachineState) =>
   state.context.isJoystickActive;
@@ -61,6 +62,7 @@ export const Hud: React.FC = () => {
             </>
           )}
         </div>
+        {isPlaying && <Equipment_Immunity />}
 
         {!isJoystickActive && (
           <>


### PR DESCRIPTION
# Description
Displays icons for equipped items that grant equipment immunity. It checks the player’s equipped aura and wings, and if they are included in the allowed immunity lists, their icons are shown in the HUD. If none are equipped, nothing is displayed.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
