### PR TITLE
[FEAT] Add health bar and fix respawn

### DIFF
--- a/src/features/portal/minigame/containers/Blast_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Blast_Skeleton.ts
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const RESTORE_SPEED = 3000;
-const MIN_NEXT_MOVE = RESTORE_SPEED + 1000;
+const MIN_NEXT_MOVE = RESTORE_SPEED + 2000;
 const MAX_NEXT_MOVE = MIN_NEXT_MOVE + 4000;
 
 export class Blast_Skeleton extends Phaser.GameObjects.Container {
@@ -22,11 +22,14 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
   private spriteName: string;
   private food: Phaser.GameObjects.Sprite;
   private tomatoBomb: Phaser.GameObjects.Sprite;
+  private bombBody!: Phaser.Physics.Arcade.Body;
   private isDefeated: boolean = false;
   private isHit: boolean = false;
   private skeletonTimer?: Phaser.Time.TimerEvent;
   private spawnX: number;
   private spawnY: number;
+  private health_bar: Phaser.GameObjects.Image;
+  private health_status: string;
 
   constructor({ x, y, scene, player }: Props) {
     super(scene, x, y);
@@ -35,6 +38,7 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     this.spriteName = "sniper_skeleton";
     this.spawnX = x;
     this.spawnY = y;
+    this.health_status = "health";
 
     this.sprite = this.scene.add
       .sprite(0, 0, `${this.spriteName}_idle`)
@@ -46,11 +50,23 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     this.tomatoBomb = this.scene.add
       .sprite(0, 0, `${this.spriteName}_tomato_screenSplat`)
       .setVisible(false);
-    this.add([this.sprite, this.tomatoBomb, this.food]);
+    this.health_bar = this.scene.add
+      .image(0, -20, `${this.health_status}_full`)
+      .setScale(0.8)
+      .setVisible(false);
+    this.add([this.sprite, this.tomatoBomb, this.food, this.health_bar]);
+
+    // Physics
     scene.physics.add.existing(this);
     (this.body as Phaser.Physics.Arcade.Body)
       .setSize(this.sprite.width, this.sprite.height)
       .setOffset(-this.sprite.width / 2, -this.sprite.height / 2);
+
+    scene.physics.add.existing(this.tomatoBomb);
+    this.bombBody = this.tomatoBomb.body as Phaser.Physics.Arcade.Body;
+    this.bombBody.setAllowGravity(false);
+    this.bombBody.setImmovable(true);
+    this.bombBody.enable = false;
 
     // Enemy
     this.scheduleAction();
@@ -75,7 +91,7 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     const delay = Phaser.Math.Between(MIN_NEXT_MOVE, MAX_NEXT_MOVE);
     this.skeletonTimer = this.scene.time.delayedCall(delay, () => {
       if (!this.player) return;
-      const targetX = this.player.x;
+      const targetX = this.player.x - 20;
       const targetY = this.player.y - 20;
 
       this.scene.time.delayedCall(200, () => {
@@ -87,11 +103,11 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
 
   private createBlast(targetX: number, targetY: number) {
     if (!this.player) return;
+    this.isDefeated = false;
 
-    this.scene.physics.add.existing(this.tomatoBomb);
-    const body = this.tomatoBomb.body as Phaser.Physics.Arcade.Body;
-    body.enable = false;
+    (this.body as Phaser.Physics.Arcade.Body).enable = true;
 
+    this.health_bar.setVisible(true);
     this.tomatoBomb.setVisible(false);
     this.sprite.setVisible(true);
     this.food.setVisible(true);
@@ -117,9 +133,10 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
         );
 
         this.sprite.setVisible(false);
+        this.health_bar.setVisible(false);
 
         this.food.once("animationcomplete", () => {
-          body.enable = true;
+          this.bombBody.enable = true;
           this.food.setVisible(false);
           this.tomatoBomb.setVisible(true);
           createAnimation(
@@ -192,26 +209,40 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
   }
 
   private createDamage() {}
-
   private createEvents() {}
 
   public defeat() {
-    if (this.isDefeated || !this.sprite.visible) return;
+    if (this.isDefeated || !this.sprite.active) return;
     this.isDefeated = true;
 
-    this.skeletonTimer?.remove(false);
-    this.sprite.setVisible(false);
-    this.food.setVisible(false);
-    this.tomatoBomb.setVisible(false);
+    this.health_bar.setTexture(`${this.health_status}_low`);
+    createAnimation(
+      this.scene,
+      this.sprite,
+      `${this.spriteName}_death`,
+      "death",
+      0,
+      4,
+      4,
+      0,
+    );
 
-    this.scene.tweens.killTweensOf(this.sprite);
-    this.scene.tweens.killTweensOf(this.tomatoBomb);
+    this.sprite.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+      this.skeletonTimer?.remove(false);
+      this.sprite.setVisible(false);
+      this.food.setVisible(false);
+      this.tomatoBomb.setVisible(false);
+      this.health_bar.setVisible(false);
 
-    (this.body as Phaser.Physics.Arcade.Body).enable = false;
-    (this.tomatoBomb.body as Phaser.Physics.Arcade.Body).enable = false;
+      this.scene.tweens.killTweensOf(this.sprite);
+      this.scene.tweens.killTweensOf(this.tomatoBomb);
 
-    this.scene.time.delayedCall(2000, () => {
-      this.respawn();
+      (this.body as Phaser.Physics.Arcade.Body).enable = false;
+      (this.tomatoBomb.body as Phaser.Physics.Arcade.Body).enable = false;
+
+      this.scene.time.delayedCall(5000, () => {
+        this.respawn();
+      });
     });
   }
 
@@ -220,16 +251,17 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     this.isDefeated = false;
     this.isHit = false;
 
-    this.setPosition(this.spawnX, this.spawnY);
+    const finalX =
+      this.spawnX +
+      (this.player.x <= 300 ? -1 : 1) * Phaser.Math.Between(10, 50);
+    this.setPosition(finalX, this.spawnY);
 
+    const randomHS = Phaser.Utils.Array.GetRandom(["full", "half"]);
+    this.health_bar.setTexture(`${this.health_status}_${randomHS}`);
+    this.health_bar.setVisible(false);
     this.sprite.setTexture(`${this.spriteName}_idle`);
-    this.sprite.setVisible(false);
-    this.food.setVisible(false);
-    this.tomatoBomb.setVisible(false);
 
-    (this.body as Phaser.Physics.Arcade.Body).enable = true;
-    (this.tomatoBomb.body as Phaser.Physics.Arcade.Body).enable = false;
-
+    (this.body as Phaser.Physics.Arcade.Body).enable = false;
     this.scheduleAction();
   }
 }


### PR DESCRIPTION
# Description
The health bar of the Blast Skeleton visually indicates its current life status. It appears above the skeleton during attacks, shows either full or low states, and updates to low when defeated, disappearing when the skeleton is inactive or respawning.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
