### PR TITLE
[FEAT] Add health bar Gian enemy and fix respawn

### DIFF
--- a/src/features/portal/minigame/containers/Giant_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Giant_Skeleton.ts
@@ -27,6 +27,8 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
   private followGiant: boolean = true;
   private isDefeated: boolean = false;
   private barrelTimer?: Phaser.Time.TimerEvent;
+  private health_bar: Phaser.GameObjects.Image;
+  private health_status: string;
 
   constructor({ x, y, scene, player }: Props) {
     super(scene, x, y);
@@ -34,11 +36,18 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
     this.scene = scene;
     this.player = player;
     this.spriteName = "giant";
+    this.health_status = "health";
 
     // Sprites
     this.sprite = this.scene.add.sprite(0, 0, `${this.spriteName}_idle`);
     this.barrel = this.scene.add.sprite(0, -20, `${this.spriteName}_barrel`);
-    this.add([this.sprite, this.barrel]);
+    this.health_bar = this.scene.add.image(
+      0,
+      -30,
+      `${this.health_status}_full`,
+    );
+    this.add([this.sprite, this.barrel, this.health_bar]);
+    this.sprite.setActive(false);
 
     // Physics
     this.scene.physics.add.existing(this.barrel);
@@ -62,6 +71,9 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
   }
 
   private createGiant() {
+    if (!this.player) return;
+    this.isDefeated = false;
+
     this.setSize(this.sprite.width, this.sprite.height);
     this.setDepth(0);
 
@@ -92,7 +104,7 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
       onUpdate: (tween, target: any) => {
         if (this.followGiant) {
           this.barrel.x = this.sprite.x;
-          this.barrel.y = this.sprite.y - 20;
+          this.barrel.y = this.sprite.y - 15;
         }
 
         const dx = target.x - prevX;
@@ -145,6 +157,8 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
       });
       this.scene.time.delayedCall(500, () => {
         if (!this.isDefeated) {
+          this.sprite.setActive(true);
+          (this.body as Phaser.Physics.Arcade.Body).enable = true;
           this.throwBarrel();
         }
       });
@@ -155,6 +169,8 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
     if (!this.player) return;
 
     this.followGiant = false;
+    this.sprite.setVisible(true);
+    this.health_bar.setVisible(true);
 
     const body = this.barrel.body as Phaser.Physics.Arcade.Body;
     body.enable = true;
@@ -233,25 +249,28 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
   private createEvents() {}
 
   public defeat() {
-    if (this.isDefeated || !this.sprite.visible) return;
+    if (this.isDefeated || !this.sprite.active) return;
     this.isDefeated = true;
 
+    this.health_bar.setTexture(`${this.health_status}_low`);
     createAnimation(
       this.scene,
       this.sprite,
       `${this.spriteName}_death`,
       "death",
       0,
-      12,
+      9,
       15,
       0,
     );
 
-    this.sprite.once("animationcomplete", () => {
+    this.sprite.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+      this.health_bar.setVisible(false);
       this.barrel.setVisible(false);
       this.sprite.setVisible(false);
 
       this.barrelTimer?.remove(false);
+      this.sprite.setActive(false);
 
       this.scene.tweens.killTweensOf(this.sprite);
       this.scene.tweens.killTweensOf(this.barrel);
@@ -270,25 +289,12 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
       const moveLeft = this.x - MOVE_DISTANCE;
       this.x = moveLeft;
 
-      this.sprite.setVisible(true);
-      this.barrel.setVisible(true);
-      this.barrel.setPosition(this.sprite.x, this.sprite.y - 20);
-
-      (this.body as Phaser.Physics.Arcade.Body).enable = true;
-      (this.barrel.body as Phaser.Physics.Arcade.Body).enable = true;
+      const randomHS = Phaser.Utils.Array.GetRandom(["full", "half"]);
+      this.health_bar.setTexture(`${this.health_status}_${randomHS}`);
+      this.health_bar.setVisible(false);
 
       this.followGiant = true;
 
-      createAnimation(
-        this.scene,
-        this.sprite,
-        `${this.spriteName}_idle`,
-        "idle",
-        0,
-        7,
-        8,
-        -1,
-      );
       this.scheduleNextBarrelThrow();
     });
   }


### PR DESCRIPTION
# Description
[FEAT] The health bar of the Gian Skeleton visually indicates its current life status. It appears above the skeleton during attacks, shows either full or low states, and updates to low when defeated, disappearing when the skeleton is inactive or respawning.

[FIX] Re-enable sprite activity after respawn by restoring sprite.setActive(true), ensuring the Giant Skeleton becomes interactive again and allowing the defeat logic to trigger properly after being revived.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
