### PR TITLE
[FIX] Fix inactive sprite state causing enemy to stall after defeat

### DIFF
--- a/src/features/portal/minigame/containers/Menace_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Menace_Skeleton.ts
@@ -63,6 +63,7 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     this.scene.physics.add.existing(this.sprite);
     const spriteBody = this.sprite.body as Phaser.Physics.Arcade.Body;
     spriteBody.setSize(this.sprite.width, this.sprite.height).setCollideWorldBounds(true).setImmovable(true);
+    this.sprite.setActive(false);
 
     this.scene.physics.add.existing(this.vege);
     const vegeBody = this.vege.body as Phaser.Physics.Arcade.Body;
@@ -95,6 +96,7 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     const delay = Phaser.Math.Between(MENACE_MIN_CREATE, MENACE_MAX_CREATE);
     this.skeletonTimer = this.scene.time.delayedCall(delay, () => {
       if (!this.isDefeated) {
+        this.sprite.setActive(true);
         this.createMenace();
         this.scheduleMenace();
       }
@@ -266,6 +268,7 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
         this.vege.setVisible(false);
         this.vegeSplat.setVisible(false);
         this.health_bar.setVisible(false);
+        this.sprite.setActive(false);
 
         this.scene.tweens.killTweensOf(this.sprite);
         this.scene.tweens.killTweensOf(this.vege);


### PR DESCRIPTION
# Description
Fixed an issue where the enemy could be defeated but would remain stuck on the screen and not proceed to its next action. This was caused by the sprite becoming inactive and not being properly reactivated during the spawn cycle.
The fix ensures that the sprite’s active state is correctly reset when the enemy spawns, allowing it to resume its behavior and be defeated again as expected.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
