### PR TITLE
[FIX] Make defeat sequence execute even if animation events fail

### DIFF
--- a/src/features/portal/minigame/containers/Giant_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Giant_Skeleton.ts
@@ -267,7 +267,7 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
       0,
     );
 
-    this.sprite.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+    this.scene.time.delayedCall(800, () => {
       this.health_bar.setVisible(false);
       this.barrel.setVisible(false);
       this.sprite.setVisible(false);

--- a/src/features/portal/minigame/containers/Menace_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Menace_Skeleton.ts
@@ -266,7 +266,7 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     this.health_bar.setTexture(`${this.health_status}_low`)
     createAnimation(this.scene, this.sprite, `${this.spriteName}_death`, "death", 0, 4, 10, 0);
     
-      this.sprite.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+    this.scene.time.delayedCall(800, () => {
         this.sprite.setVisible(false);
         this.vege.setVisible(false);
         this.vegeSplat.setVisible(false);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue
Replaced `ANIMATION_COMPLETE` with a timed `delayedCall` to ensure the defeat sequence (hiding the sprite, stopping tweens, and respawning) always runs. Using `ANIMATION_COMPLETE` is cleaner because it automatically waits for the animation to finish, but if animations can be interrupted or Phaser sometimes misses the event, a timed `delayedCall` is a reliable fallback. Just make sure the delay matches the actual animation duration so it doesn’t hide the sprite too early or too late.

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
