### PR TITLE
[FEAT] Replace velocity debuff with inverted control debuff

### DIFF
--- a/src/features/portal/minigame/Core/BaseScene.ts
+++ b/src/features/portal/minigame/Core/BaseScene.ts
@@ -104,6 +104,7 @@ export abstract class BaseScene extends Phaser.Scene {
   public map: Phaser.Tilemaps.Tilemap = {} as Phaser.Tilemaps.Tilemap;
   public borderMapLeft?: Phaser.Tilemaps.Tilemap;
   public borderMapRight?: Phaser.Tilemaps.Tilemap;
+  public isControlInverted: boolean = false;
 
   npcs: Partial<Record<NPCName, BumpkinContainer>> = {};
 
@@ -126,17 +127,17 @@ export abstract class BaseScene extends Phaser.Scene {
 
   cursorKeys:
     | {
-      up: Phaser.Input.Keyboard.Key;
-      down: Phaser.Input.Keyboard.Key;
-      left: Phaser.Input.Keyboard.Key;
-      right: Phaser.Input.Keyboard.Key;
-      w?: Phaser.Input.Keyboard.Key;
-      s?: Phaser.Input.Keyboard.Key;
-      a?: Phaser.Input.Keyboard.Key;
-      d?: Phaser.Input.Keyboard.Key;
-      e?: Phaser.Input.Keyboard.Key;
-      space: Phaser.Input.Keyboard.Key;
-    }
+        up: Phaser.Input.Keyboard.Key;
+        down: Phaser.Input.Keyboard.Key;
+        left: Phaser.Input.Keyboard.Key;
+        right: Phaser.Input.Keyboard.Key;
+        w?: Phaser.Input.Keyboard.Key;
+        s?: Phaser.Input.Keyboard.Key;
+        a?: Phaser.Input.Keyboard.Key;
+        d?: Phaser.Input.Keyboard.Key;
+        e?: Phaser.Input.Keyboard.Key;
+        space: Phaser.Input.Keyboard.Key;
+      }
     | undefined;
 
   // Advanced server timing - not used
@@ -297,7 +298,6 @@ export abstract class BaseScene extends Phaser.Scene {
 
     try {
       this.initialiseMap();
-
 
       const mapWidthPx = this.map.width * SQUARE_WIDTH;
       const mapHeightPx = this.map.height * SQUARE_WIDTH;
@@ -606,13 +606,37 @@ export abstract class BaseScene extends Phaser.Scene {
 
     const extraCols = Math.ceil(extraWidthPx / this.zoom / SQUARE_WIDTH);
 
-    this.borderMapLeft = this.make.tilemap({ tileWidth: SQUARE_WIDTH, tileHeight: SQUARE_WIDTH, width: extraCols, height: this.map.height });
-    this.borderMapRight = this.make.tilemap({ tileWidth: SQUARE_WIDTH, tileHeight: SQUARE_WIDTH, width: extraCols, height: this.map.height });
+    this.borderMapLeft = this.make.tilemap({
+      tileWidth: SQUARE_WIDTH,
+      tileHeight: SQUARE_WIDTH,
+      width: extraCols,
+      height: this.map.height,
+    });
+    this.borderMapRight = this.make.tilemap({
+      tileWidth: SQUARE_WIDTH,
+      tileHeight: SQUARE_WIDTH,
+      width: extraCols,
+      height: this.map.height,
+    });
 
     const tilesetKey = this.options.map?.tilesetUrl ?? "Sunnyside V3";
     const imageKey = this.options.map?.imageKey ?? "tileset";
-    const tilesetLeft = this.borderMapLeft.addTilesetImage(tilesetKey, imageKey, 16, 16, 1, 2) as Phaser.Tilemaps.Tileset;
-    const tilesetRight = this.borderMapRight.addTilesetImage(tilesetKey, imageKey, 16, 16, 1, 2) as Phaser.Tilemaps.Tileset;
+    const tilesetLeft = this.borderMapLeft.addTilesetImage(
+      tilesetKey,
+      imageKey,
+      16,
+      16,
+      1,
+      2,
+    ) as Phaser.Tilemaps.Tileset;
+    const tilesetRight = this.borderMapRight.addTilesetImage(
+      tilesetKey,
+      imageKey,
+      16,
+      16,
+      1,
+      2,
+    ) as Phaser.Tilemaps.Tileset;
 
     const TOP_LAYERS = [
       "Decorations Layer 1",
@@ -630,8 +654,18 @@ export abstract class BaseScene extends Phaser.Scene {
     this.map.layers.forEach((layerData) => {
       if (layerData.name === "Ground") return;
 
-      const leftLayer = this.borderMapLeft!.createBlankLayer(layerData.name, tilesetLeft, -extraCols * SQUARE_WIDTH, 0) as Phaser.Tilemaps.TilemapLayer;
-      const rightLayer = this.borderMapRight!.createBlankLayer(layerData.name, tilesetRight, mapWidthPx, 0) as Phaser.Tilemaps.TilemapLayer;
+      const leftLayer = this.borderMapLeft!.createBlankLayer(
+        layerData.name,
+        tilesetLeft,
+        -extraCols * SQUARE_WIDTH,
+        0,
+      ) as Phaser.Tilemaps.TilemapLayer;
+      const rightLayer = this.borderMapRight!.createBlankLayer(
+        layerData.name,
+        tilesetRight,
+        mapWidthPx,
+        0,
+      ) as Phaser.Tilemaps.TilemapLayer;
 
       for (let y = 0; y < this.map.height; y++) {
         let startLeft = -1;
@@ -647,12 +681,15 @@ export abstract class BaseScene extends Phaser.Scene {
           const blockSizeLeft = Math.min(4, availableLeft);
           const blockLeft = [];
           for (let i = 0; i < blockSizeLeft; i++) {
-            blockLeft.push(this.map.getTileAt(startLeft + i, y, true, layerData.name));
+            blockLeft.push(
+              this.map.getTileAt(startLeft + i, y, true, layerData.name),
+            );
           }
           for (let x = 0; x < extraCols; x++) {
             const cx = x - extraCols;
             const relative_x = cx - startLeft;
-            const blockIndex = (relative_x % blockSizeLeft + blockSizeLeft) % blockSizeLeft;
+            const blockIndex =
+              ((relative_x % blockSizeLeft) + blockSizeLeft) % blockSizeLeft;
             const tile = blockLeft[blockIndex];
             if (tile && tile.index !== -1) {
               leftLayer.putTileAt(tile.index - 1, x, y);
@@ -673,7 +710,9 @@ export abstract class BaseScene extends Phaser.Scene {
           const blockRight = [];
           const startIdx = startRight - blockSizeRight + 1;
           for (let i = 0; i < blockSizeRight; i++) {
-            blockRight.push(this.map.getTileAt(startIdx + i, y, true, layerData.name));
+            blockRight.push(
+              this.map.getTileAt(startIdx + i, y, true, layerData.name),
+            );
           }
           for (let x = 0; x < extraCols; x++) {
             const cx = x + this.map.width;
@@ -701,7 +740,8 @@ export abstract class BaseScene extends Phaser.Scene {
     const mapHeightPx = this.map.height * SQUARE_WIDTH;
 
     const extraWidthPx = (window.innerWidth - mapWidthPx * this.zoom) / 2;
-    const extraCols = extraWidthPx > 0 ? Math.ceil(extraWidthPx / this.zoom / SQUARE_WIDTH) : 0;
+    const extraCols =
+      extraWidthPx > 0 ? Math.ceil(extraWidthPx / this.zoom / SQUARE_WIDTH) : 0;
     const expandedWidthPx = extraCols * SQUARE_WIDTH;
 
     camera.setBounds(
@@ -1155,7 +1195,14 @@ export abstract class BaseScene extends Phaser.Scene {
       const down =
         (this.cursorKeys?.down.isDown || this.cursorKeys?.s?.isDown) ?? false;
 
-      this.movementAngle = this.keysToAngle(left, right, up, down);
+      const inverted = this.keysToAngle(
+        this.isControlInverted ? right : left,
+        this.isControlInverted ? left : right,
+        this.isControlInverted ? down : up,
+        this.isControlInverted ? up : down,
+      );
+
+      this.movementAngle = inverted;
     }
 
     // change player direction if angle is changed from left to right or vise versa

--- a/src/features/portal/minigame/containers/Sniper_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Sniper_Skeleton.ts
@@ -1,7 +1,7 @@
 import { BumpkinContainer } from "../Core/BumpkinContainer";
 import { Scene } from "../Scene";
 import { createAnimation } from "../lib/Utils";
-import { SHOES_IMMUNITY, WALKING_SPEED } from "../Constants";
+import { SHOES_IMMUNITY } from "../Constants";
 import { MachineInterpreter } from "../lib/Machine";
 
 interface Props {
@@ -13,7 +13,7 @@ interface Props {
 
 const SNIPER_MIN_CREATE = 4000;
 const SNIPER_MAX_CREATE = 6000;
-const DEBUFF_DURATION = 400;
+const DEBUFF_DURATION = 3000;
 
 export class Sniper_Skeleton extends Phaser.GameObjects.Container {
   scene: Scene;
@@ -84,7 +84,7 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
     this.scene.tweens.add({
       targets: sprite,
       onStart: () => {
-          this.scene.sound.play("sniper_spawn", { volume: 0.2 });
+        this.scene.sound.play("sniper_spawn", { volume: 0.2 });
       },
       x: originalX + Phaser.Math.Between(-4, 4),
       y: originalY + Phaser.Math.Between(-4, 4),
@@ -227,14 +227,13 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
     if (!this.player) return;
 
     const shoe = this.player.clothing.shoes;
-    const debuffSpeed = WALKING_SPEED * 7;
 
     if (!shoe) {
-      this.scene.velocity = debuffSpeed;
+      this.scene.isControlInverted = true;
     } else if (SHOES_IMMUNITY.includes(shoe)) {
-      this.scene.velocity = WALKING_SPEED;
+      this.scene.isControlInverted = false;
     } else {
-      this.scene.velocity = debuffSpeed;
+      this.scene.isControlInverted = true;
     }
 
     this.restorePlayer();
@@ -243,7 +242,7 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
   private restorePlayer() {
     this.scene.time.delayedCall(
       DEBUFF_DURATION,
-      () => (this.scene.velocity = WALKING_SPEED),
+      () => (this.scene.isControlInverted = false),
     );
   }
 


### PR DESCRIPTION
# Description
Replaces the old velocity debuff with a temporary inverted control effect, causing the player’s movement inputs to be reversed for a short duration when hit by the Sniper Skeleton.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
