### PR TITLE
[FIX] Enemy attacks when scaled 2x and calibrate spawn time

### DIFF
--- a/src/features/portal/minigame/Constants.ts
+++ b/src/features/portal/minigame/Constants.ts
@@ -216,12 +216,12 @@ export const HAT_IMMUNITY: BumpkinHat = "Grumpy Cat";
 export const MENACE_SKELETON_POSITIONS: Position[] = [
   { x: 320, y: 60 },
   { x: 150, y: 70 },
-  { x: 450, y: 72 },
-  { x: 230, y: 110 },
+  // { x: 450, y: 72 },
+  // { x: 230, y: 110 },
 ];
 
 export const BLAST_SKELETON_POSITIONS: { x: number; y: number }[] = [
-  { x: 300, y: 210 },
+  { x: 340, y: 200 },
 ];
 
 export const DRIP_WALKER_POSITIONS: (Position & { side: Side })[] = [

--- a/src/features/portal/minigame/containers/Blast_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Blast_Skeleton.ts
@@ -12,8 +12,8 @@ interface Props {
 }
 
 const RESTORE_SPEED = 3000;
-const MIN_NEXT_MOVE = RESTORE_SPEED + 3000;
-const MAX_NEXT_MOVE = RESTORE_SPEED + 5000;
+const MIN_NEXT_MOVE = RESTORE_SPEED + 5000;
+const MAX_NEXT_MOVE = RESTORE_SPEED + 8000;
 
 export class Blast_Skeleton extends Phaser.GameObjects.Container {
   scene: Scene;
@@ -213,8 +213,8 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     if (this.isDefeated) return;
     this.scene.time.delayedCall(1000, () => {
       if (!this.player || this.isDefeated) return;
-      // const finalX = this.spawnX + (this.player.x <= 300 ? -1 : 1) * Phaser.Math.Between(10, 50);
-      this.setPosition(this.spawnX, this.spawnY);
+      const finalX = Phaser.Utils.Array.GetRandom([270, 340]);;
+      this.setPosition(finalX, this.spawnY);
       this.tomatoBomb.setVisible(false);
       this.food.setTexture(`${this.spriteName}_tomato`);
       this.food.setVisible(false);
@@ -306,10 +306,8 @@ export class Blast_Skeleton extends Phaser.GameObjects.Container {
     this.isDefeated = false;
     this.isHit = false;
 
-    const finalX =
-      this.spawnX +
-      (this.player.x <= 300 ? -1 : 1) * Phaser.Math.Between(10, 50);
-    this.setPosition(finalX, this.spawnY);
+    const finalX = this.spawnX + (this.player.x <= 300 ? -1 : 1) * Phaser.Utils.Array.GetRandom([280, 340]);;
+    this.setPosition(finalX / this.scale, this.spawnY);
 
     const randomHS = Phaser.Utils.Array.GetRandom(["full", "half"]);
     this.health_bar.setTexture(`${this.health_status}_${randomHS}`);

--- a/src/features/portal/minigame/containers/Giant_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Giant_Skeleton.ts
@@ -181,14 +181,14 @@ export class Giant_Skeleton extends Phaser.GameObjects.Container {
     this.setDepth(200);
 
     const distance = this.direction === 1 ? "+=150" : "-=150";
-    const valueY = this.player.getWorldTransformMatrix().ty - this.y;
+    const playerWorldY = this.player.getWorldTransformMatrix().ty;
     this.scene.sound.add("barrel", { volume: 0.2 }).play();
-
+    const localY = (playerWorldY - this.y) / this.scaleY;
     this.scene.tweens.add({
       targets: this.barrel,
       props: {
         x: { value: distance, duration: 2500, ease: "Power4" },
-        y: { value: `${valueY}`, duration: 2000, ease: "Bounce" },
+        y: { value: `${localY}`, duration: 2000, ease: "Bounce" },
       },
       onComplete: () => this.resetBarrel(),
     });

--- a/src/features/portal/minigame/containers/Menace_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Menace_Skeleton.ts
@@ -198,11 +198,11 @@ export class Menace_Skeleton extends Phaser.GameObjects.Container {
     this.vege.setFlipX(this.flipX);
     this.vegeSplat.setFlipX(this.flipX);
     this.vegeSplat.setPosition(this.randomThrow, playerWorldY - this.y);
-
+    const localY = (playerWorldY - this.y) / this.scaleY;
     this.scene.add.tween({
       targets: this.vege,
       x: this.randomThrow,
-      y: playerWorldY - this.y,
+      y: localY,
       duration: throwSpeed,
       ease: "Quad.Out",
       onComplete: () => {

--- a/src/features/portal/minigame/containers/Sniper_Skeleton.ts
+++ b/src/features/portal/minigame/containers/Sniper_Skeleton.ts
@@ -11,8 +11,8 @@ interface Props {
   player?: BumpkinContainer;
 }
 
-const SNIPER_MIN_CREATE = 4000;
-const SNIPER_MAX_CREATE = 6000;
+const SNIPER_MIN_CREATE = 6000;
+const SNIPER_MAX_CREATE = 8000;
 const DEBUFF_DURATION = 3000;
 
 export class Sniper_Skeleton extends Phaser.GameObjects.Container {
@@ -42,6 +42,7 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
       .setVisible(false);
     this.add([this.sprite, this.vege]);
     this.sprite.setVisible(false);
+    this.sprite.setOrigin(0, 0);
 
     // Physics
     this.scene.physics.add.existing(this);
@@ -82,17 +83,22 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
     (this.body as Phaser.Physics.Arcade.Body).enable = true;
 
     const sprite = this.sprite;
-    const originalX = this.player.getWorldTransformMatrix().tx - this.x;
+    const originalX = (this.player.getWorldTransformMatrix().tx - this.x) / this.scale;
     const originalY = sprite.y;
     const originalScaleX = sprite.scaleX;
     const originalScaleY = sprite.scaleY;
+
+    const minX = 150;
+    const maxX = 400;
 
     this.scene.tweens.add({
       targets: sprite,
       onStart: () => {
         this.scene.sound.play("sniper_spawn", { volume: 0.2 });
       },
-      x: originalX + Phaser.Math.Between(-4, 4),
+      x: {
+      getEnd: () => Phaser.Math.Clamp(originalX + Phaser.Math.Between(-4, 4), minX, maxX),
+    },
       y: originalY + Phaser.Math.Between(-4, 4),
       scaleX: originalScaleX + Phaser.Math.FloatBetween(-0.08, 0.08),
       scaleY: originalScaleY + Phaser.Math.FloatBetween(-0.08, 0.08),
@@ -179,14 +185,16 @@ export class Sniper_Skeleton extends Phaser.GameObjects.Container {
     const playerWorldX = this.player.getWorldTransformMatrix().tx;
     const playerWorldY = this.player.getWorldTransformMatrix().ty;
     const flipX = this.player.x < this.x ? true : false;
-    const targetX =
-      flipX === true ? playerWorldX - this.x : playerWorldX - this.x;
+    // const targetX = flipX === true ? playerWorldX - this.x : playerWorldX - this.x;
     const throwSpeed = playerWorldY < 297 ? 250 : 300;
-
+    const localX = flipX
+      ? (playerWorldX - this.x - 10) / this.scaleX  
+      : (playerWorldX - this.x + 10) / this.scaleX;
+    const localY = (playerWorldY - this.y) / this.scaleY;
     this.scene.add.tween({
       targets: this.vege,
-      x: targetX,
-      y: playerWorldY - this.y,
+      x: localX,
+      y: localY,
       duration: throwSpeed,
       ease: "Quad.Out",
       onComplete: () => {


### PR DESCRIPTION
# Description
Fixed issues causing enemy attack behavior and positioning to break when affected by the 2x growth effect. Adjusted spawn timing and reduced enemy count to improve overall balance and prevent overcrowding.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
